### PR TITLE
Changed WalletConnect version

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
     <script type="text/javascript" src="https://unpkg.com/web3@1.2.11/dist/web3.min.js"></script>
     <script type="text/javascript" src="https://unpkg.com/web3modal@1.9.0/dist/index.js"></script>
     <script type="text/javascript" src="https://unpkg.com/evm-chains@0.2.0/dist/umd/index.min.js"></script>
-    <script type="text/javascript" src="https://unpkg.com/@walletconnect/web3-provider@1.2.1/dist/umd/index.min.js"></script>
+    <script type="text/javascript" src="https://unpkg.com/@walletconnect/web3-provider@1.6.5/dist/umd/index.min.js"></script>
     <script type="text/javascript" src="https://unpkg.com/fortmatic@2.0.6/dist/fortmatic.js"></script>
 
     <!-- This is our example code -->


### PR DESCRIPTION
Changed Walletconnect version to the newest one. Versions below 1.6 are deprecated and do not work properly.
(https://twitter.com/WalletConnect/status/1426226788515078144?s=20)
